### PR TITLE
Add MosaicCategory component to home page

### DIFF
--- a/app/(user)/page.tsx
+++ b/app/(user)/page.tsx
@@ -3,12 +3,14 @@ import Banner from "@/components/home/Banner";
 import FeaturedProduct from "@/components/home/FeaturedProduct";
 import HeaderSlider from "@/components/home/HeaderSlider";
 import HomeProducts from "@/components/home/HomeProducts";
+import MosaicCategory from "@/components/home/MosaicCategory";
 import NewsLetter from "@/components/home/NewsLetter";
 import { MessageCircle } from "lucide-react";
 
 export default function Home() {
   return (
     <>
+      <MosaicCategory />
       <HeaderSlider />
       <HomeProducts />
       <FeaturedProduct />

--- a/components/home/MosaicCategory.tsx
+++ b/components/home/MosaicCategory.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { assets } from "@/assets/assets";
+import { Card } from "../ui/card";
+import Image, { StaticImageData } from "next/image";
+import { Button } from "../ui/button";
+import clsx from "clsx";
+
+type Category = {
+  label: string;
+  image: StaticImageData;
+  align?: "left" | "center" | "right";
+};
+
+const categories: Category[] = [
+  { label: "Música", image: assets.girl_with_headphone_image, align: "center" },
+  { label: "Podcast", image: assets.girl_with_headphone_image, align: "right" },
+  {
+    label: "Conciertos",
+    image: assets.girl_with_headphone_image,
+    align: "left",
+  },
+  {
+    label: "Entrevistas",
+    image: assets.girl_with_headphone_image,
+    align: "center",
+  },
+];
+
+const MosaicCategory = () => {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 gap-4 p-4 h-[85vh]">
+      <div className="lg:row-span-2 h-full">
+        <CategoryCard
+          label={categories[0].label}
+          image={categories[0].image}
+          align={categories[0].align}
+          fullHeight
+        />
+      </div>
+      <div className="lg:row-span-2 h-full">
+        <CategoryCard
+          label={categories[1].label}
+          image={categories[1].image}
+          align={categories[1].align}
+          fullHeight
+        />
+      </div>
+      <CategoryCard
+        label={categories[2].label}
+        image={categories[2].image}
+        align={categories[2].align}
+      />
+      <CategoryCard
+        label={categories[3].label}
+        image={categories[3].image}
+        align={categories[3].align}
+      />
+    </div>
+  );
+};
+
+const CategoryCard = ({
+  label,
+  image,
+  align = "left",
+  fullHeight = false,
+}: {
+  label: string;
+  image: StaticImageData;
+  align?: "left" | "center" | "right";
+  fullHeight?: boolean;
+}) => {
+  const buttonPosition = {
+    left: "left-4",
+    center: "left-1/2 -translate-x-1/2",
+    right: "right-4",
+  };
+
+  return (
+    <Card
+      className={clsx(
+        "relative overflow-hidden group w-full rounded-2xl",
+        fullHeight ? "h-full" : "h-full"
+      )}
+    >
+      <Image
+        src={image}
+        alt={label}
+        fill
+        className={clsx(
+          "object-cover transition-transform duration-500 ease-in-out",
+          "group-hover:scale-105"
+        )}
+      />
+      <Button
+        className={clsx(
+          "absolute bottom-4 z-10 transform",
+          buttonPosition[align]
+        )}
+      >
+        {label}
+      </Button>
+      <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/10 to-transparent z-0 rounded-2xl" />
+    </Card>
+  );
+};
+
+export default MosaicCategory;


### PR DESCRIPTION
Introduces a new MosaicCategory component displaying category cards in a grid layout on the home page. The component is integrated into the main user page and visually highlights categories such as Música, Podcast, Conciertos, and Entrevistas.