### PR TITLE
Refactor products and sales pages to use product store

### DIFF
--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -1,7 +1,5 @@
 "use client";
-import { getProducts } from "@/actions";
 import { DeleteProductAlert } from "@/components/product/belete-product-alert";
-import { Product } from "@/components/product/interface";
 import { ProductStatusBadge } from "@/components/product/product-status-badge";
 import {
   Table,
@@ -11,18 +9,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useProductStore } from "@/stores/user/product-store";
 import Image from "next/image";
-import { useEffect, useState } from "react";
 
 export default function ProductsAdmin() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const fetchProducts = async () => {
-    const res = await getProducts();
-    setProducts(res.products || []);
-  };
-  useEffect(() => {
-    fetchProducts();
-  }, []);
+  const { products, fetchProducts } = useProductStore();
 
   return (
     <div>

--- a/app/admin/sales/page.tsx
+++ b/app/admin/sales/page.tsx
@@ -1,7 +1,5 @@
 "use client";
-import { getProducts } from "@/actions";
 import { DeleteProductAlert } from "@/components/product/belete-product-alert";
-import { Product } from "@/components/product/interface";
 import { ProductStatusBadge } from "@/components/product/product-status-badge";
 import {
   Table,
@@ -11,18 +9,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useProductStore } from "@/stores/user/product-store";
 import Image from "next/image";
-import { useEffect, useState } from "react";
 
 export default function SalesAdminPage() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const fetchProducts = async () => {
-    const res = await getProducts();
-    setProducts(res.products || []);
-  };
-  useEffect(() => {
-    fetchProducts();
-  }, []);
+  const { products , fetchProducts } = useProductStore();
 
   return (
     <div>


### PR DESCRIPTION
Replaced local state and effect-based product fetching in admin products and sales pages with the useProductStore hook for improved state management and code reuse.