### PR TITLE
Adjust padding and remove extra class in layout and MosaicCategory

### DIFF
--- a/app/(user)/layout.tsx
+++ b/app/(user)/layout.tsx
@@ -9,7 +9,7 @@ export default function UserLayout({
   return (
     <>
       <Navbar />
-      <main className="px-4 md:px-16 lg:px-32">{children}</main>
+      <main className="px-3 md:px-16 lg:px-32">{children}</main>
       <Footer />
     </>
   );

--- a/components/home/MosaicCategory.tsx
+++ b/components/home/MosaicCategory.tsx
@@ -42,7 +42,7 @@ const categories: Category[] = [
 
 const MosaicCategory = () => {
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 gap-4 p-4 h-[85vh]">
+    <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 gap-4 h-[85vh]">
       <div className="lg:row-span-2 h-full">
         <CategoryCard
           label={categories[0].label}


### PR DESCRIPTION
Reduced horizontal padding in UserLayout main container from 4 to 3. Removed unnecessary 'p-4' class from MosaicCategory grid container for cleaner layout.