### PR TITLE
Uncomment HTML preview in simple editor

### DIFF
--- a/components/shared/simple-editor.tsx
+++ b/components/shared/simple-editor.tsx
@@ -137,9 +137,9 @@ export function HtmlEditor({
         style={{ cursor: "text" }}
         data-placeholder={placeholder}
       />
-      {/* <pre>
+      <pre>
         <code className="text-sm">{html}</code>
-      </pre> */}
+      </pre>
     </div>
   );
 }


### PR DESCRIPTION
Restores the HTML preview block in the HtmlEditor component by uncommenting the <pre><code> section. This allows developers to see the rendered HTML output for debugging or development purposes.