### PR TITLE
Comment out social login buttons and remove OpenGraph metadata

### DIFF
--- a/app/auth/sign-in/[[...sign-in]]/page.tsx
+++ b/app/auth/sign-in/[[...sign-in]]/page.tsx
@@ -15,12 +15,9 @@ import { Label } from "@/components/ui/label";
 import Link from "next/link";
 import { LogoTheme } from "@/components/shared/logo-theme";
 import {
-  FacebookIcon,
-  LoaderCircleIcon,
   ShieldIcon,
   User2Icon,
 } from "lucide-react";
-import { Icons } from "@/components/icons";
 
 export default function SignInPage() {
   return (
@@ -42,7 +39,7 @@ export default function SignInPage() {
                     </CardHeader>
 
                     <CardContent className="grid gap-y-4">
-                      <div className="grid grid-cols-3 gap-x-4">
+                      {/* <div className="grid grid-cols-3 gap-x-4">
                         <Clerk.Connection name="apple" asChild>
                           <Button
                             size="sm"
@@ -106,7 +103,7 @@ export default function SignInPage() {
                             </Clerk.Loading>
                           </Button>
                         </Clerk.Connection>
-                      </div>
+                      </div> */}
                       <p className="flex items-center gap-x-3 text-sm text-muted-foreground before:h-px before:flex-1 before:bg-border after:h-px after:flex-1 after:bg-border">
                         ó
                       </p>

--- a/app/auth/sign-up/[[...sign-up]]/page.tsx
+++ b/app/auth/sign-up/[[...sign-up]]/page.tsx
@@ -36,7 +36,7 @@ export default function SignUpPage() {
                     </CardHeader>
                     <CardContent className="grid gap-y-4">
                       <div className="grid grid-cols-3 gap-x-4">
-                        <Clerk.Connection name="apple" asChild>
+                        {/* <Clerk.Connection name="apple" asChild>
                           <Button
                             size="sm"
                             variant="outline"
@@ -46,11 +46,9 @@ export default function SignUpPage() {
                             <Clerk.Loading scope="provider:apple">
                               {(isLoading) =>
                                 isLoading ? (
-                                  // <Icons.spinner className="size-4 animate-spin" />
                                   <div>Cargando</div>
                                 ) : (
                                   <>
-                                    {/* <Icons.gitHub className="mr-2 size-4" /> */}
                                     Apple
                                   </>
                                 )
@@ -68,11 +66,9 @@ export default function SignUpPage() {
                             <Clerk.Loading scope="provider:google">
                               {(isLoading) =>
                                 isLoading ? (
-                                  // <Icons.spinner className="size-4 animate-spin" />
                                   <div>Cargando</div>
                                 ) : (
                                   <>
-                                    {/* <Icons.google className="mr-2 size-4" /> */}
                                     Google
                                   </>
                                 )
@@ -90,18 +86,16 @@ export default function SignUpPage() {
                             <Clerk.Loading scope="provider:facebook">
                               {(isLoading) =>
                                 isLoading ? (
-                                  // <Icons.spinner className="size-4 animate-spin" />
                                   <div>Cargando</div>
                                 ) : (
                                   <>
-                                    {/* <Icons.google className="mr-2 size-4" /> */}
                                     Facebook
                                   </>
                                 )
                               }
                             </Clerk.Loading>
                           </Button>
-                        </Clerk.Connection>
+                        </Clerk.Connection> */}
                       </div>
                       <p className="flex items-center gap-x-3 text-sm text-muted-foreground before:h-px before:flex-1 before:bg-border after:h-px after:flex-1 after:bg-border">
                         ó

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,21 +29,6 @@ export const metadata: Metadata = {
     "User Authentication",
     "Server Actions",
   ],
-  openGraph: {
-    title: "Fastery Shop Template",
-    description: "A simple ecommerce template built with Next.js and Clerk",
-    url: "https://fastery-shop-template.vercel.app",
-    siteName: "Fastery Shop Template",
-    images: [
-      {
-        url: "https://fastery-shop-template.vercel.app/og-image.png",
-        width: 1200,
-        height: 630,
-      },
-    ],
-    locale: "es_MX",
-    type: "website",
-  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Social login buttons for Apple, Google, and Facebook have been commented out in the sign-in and sign-up pages. OpenGraph metadata has been removed from the app layout. These changes may be for simplifying the authentication UI and metadata configuration.