### PR TITLE
Update file upload API endpoint

### DIFF
--- a/actions/files/upload-file.ts
+++ b/actions/files/upload-file.ts
@@ -3,7 +3,7 @@ export const uploadFile = async (file: File) => {
     const formData = new FormData();
     formData.append("file", file);
     const response = await fetch(
-      `https://api.nexus.fastery.dev/api/files/uploadToFolder/nextjs-ecommerce-template`,
+      `https://api.nexus.fastery.dev/api/files/uploadToFolder/prod-ecommerce-cabellosdelsol`,
       {
         method: "POST",
         body: formData,


### PR DESCRIPTION
Changed the upload URL to use the 'prod-ecommerce-cabellosdelsol' folder instead of 'nextjs-ecommerce-template' for file uploads.