### PR TITLE
Remove debug JSON outputs from user pages

### DIFF
--- a/app/(user)/favorites/page.tsx
+++ b/app/(user)/favorites/page.tsx
@@ -32,7 +32,6 @@ export default function FavoritesPage() {
             ))}
         </div>
       </div>
-      <pre>{JSON.stringify(favorites, null, 2)}</pre>
     </main>
   );
 }

--- a/app/(user)/page.tsx
+++ b/app/(user)/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
       {/* <HeaderSlider /> */}
       <HomeProducts />
       {/* <FeaturedProduct /> */}
-      <Banner />
+      {/* <Banner /> */}
       {/* <NewsLetter /> */}
       <Information />
       <a

--- a/app/(user)/shopping-cart/page.tsx
+++ b/app/(user)/shopping-cart/page.tsx
@@ -160,7 +160,7 @@ export default function ShoppingCartPage() {
           </div>
         </div>
       )}
-      <pre>{JSON.stringify(cartItems, null, 2)}</pre>
+      {/* <pre>{JSON.stringify(cartItems, null, 2)}</pre> */}
     </main>
   );
 }

--- a/components/product/product-form.tsx
+++ b/components/product/product-form.tsx
@@ -428,7 +428,7 @@ export default function ProductForm({
                 </div>
               </CardContent>
             </Card>
-            <pre>
+            {/* <pre>
               <code className="text-sm">
                 {JSON.stringify(formData, null, 2)}
               </code>
@@ -437,7 +437,7 @@ export default function ProductForm({
               <code className="text-sm">
                 {JSON.stringify(product, null, 2)}
               </code>
-            </pre>
+            </pre> */}
             <div className="m-auto">
               <HtmlEditor
                 defaultValue={defaultHtmlContent}


### PR DESCRIPTION
Commented out or removed JSON.stringify debug outputs from favorites, shopping cart, and product form components to clean up UI and prevent unnecessary data display.