### PR TITLE
Add /product/ to public route matcher

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 // Rutas públicas accesibles sin login
-const isPublicRoute = createRouteMatcher(["/", "/terminos-y-condiciones"]);
+const isPublicRoute = createRouteMatcher(["/","/product/", "/terminos-y-condiciones"]);
 
 // Rutas del sistema de auth de Clerk
 const isAuthRoute = createRouteMatcher([


### PR DESCRIPTION
Included '/product/' in the list of public routes accessible without login to allow unauthenticated users to access product pages.