### PR TITLE
Update sidebar secondary nav and link handling

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -14,7 +14,7 @@ import {
 import {
   ListTodoIcon,
   PackageIcon,
-  SettingsIcon,
+  ServerIcon,
   TagIcon,
   UserIcon,
 } from "lucide-react";
@@ -56,14 +56,9 @@ const data = {
   ],
   navSecondary: [
     {
-      title: "Settings",
-      url: "#",
-      icon: SettingsIcon,
-    },
-    {
-      title: "Get Help",
-      url: "#",
-      icon: ListTodoIcon,
+      title: "Pago de Mantenimiento",
+      url: "https://www.fastery.dev/",
+      icon: ServerIcon,
     },
   ],
 };

--- a/components/nav-secondary.tsx
+++ b/components/nav-secondary.tsx
@@ -10,6 +10,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { LucideProps } from "lucide-react";
+import Link from "next/link";
 
 export function NavSecondary({
   items,
@@ -30,10 +31,10 @@ export function NavSecondary({
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
               <SidebarMenuButton asChild>
-                <a href={item.url}>
+                <Link href={item.url} target="_blank" rel="noreferrer">
                   <item.icon />
                   <span>{item.title}</span>
-                </a>
+                </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}


### PR DESCRIPTION
Replaced 'Settings' and 'Get Help' with 'Pago de Mantenimiento' in sidebar secondary navigation, updated icon to ServerIcon, and switched anchor tags to Next.js Link for external navigation with proper attributes.