### PR TITLE
Add category image and home display support

### DIFF
--- a/app/admin/categories/page.tsx
+++ b/app/admin/categories/page.tsx
@@ -17,6 +17,7 @@ import { useEffect } from "react";
 import { toast } from "sonner";
 import { TagIcon } from "lucide-react";
 import { PageHeader } from "@/components/shared/page-header";
+import Image from "next/image";
 
 export default function CategoriesPage() {
   const { categories, fetchCategories, deleteCategory } = useCategoryStore();
@@ -77,15 +78,33 @@ export default function CategoriesPage() {
         <Table>
           <TableHeader className="bg-muted sticky top-0 z-10">
             <TableRow>
+              <TableHead>Imagen</TableHead>
               <TableHead>Nombre</TableHead>
               <TableHead>Descripción</TableHead>
               <TableHead>Estado</TableHead>
+              <TableHead>En Inicio</TableHead>
               <TableHead>Acciones</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {categories.map((category) => (
               <TableRow key={category.id}>
+                <TableCell>
+                  {category.urlImage ? (
+                    <div className="relative w-16 h-16">
+                      <Image
+                        src={category.urlImage}
+                        alt={category.name}
+                        fill
+                        className="object-cover rounded-md border"
+                      />
+                    </div>
+                  ) : (
+                    <div className="w-16 h-16 bg-gray-100 rounded-md flex items-center justify-center">
+                      <TagIcon className="w-6 h-6 text-gray-400" />
+                    </div>
+                  )}
+                </TableCell>
                 <TableCell className="font-medium">{category.name}</TableCell>
                 <TableCell>{category.description}</TableCell>
                 <TableCell>
@@ -94,6 +113,14 @@ export default function CategoriesPage() {
                     className={`px-2 py-0.5 flex items-center gap-1`}
                   >
                     {category.isActive ? "Activo" : "Inactivo"}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={category.inHome ? "default" : "secondary"}
+                    className={`px-2 py-0.5 flex items-center gap-1`}
+                  >
+                    {category.inHome ? "Sí" : "No"}
                   </Badge>
                 </TableCell>
                 <TableCell className="space-x-2">

--- a/app/auth/sign-in/[[...sign-in]]/page.tsx
+++ b/app/auth/sign-in/[[...sign-in]]/page.tsx
@@ -36,7 +36,7 @@ export default function SignInPage() {
                     </CardHeader>
 
                     <CardContent className="grid gap-y-4">
-                      <div className="grid grid-cols-3 gap-x-4">
+                      <div className="grid grid-cols-2 gap-x-4">
                         <Clerk.Connection name="apple" asChild>
                           <Button
                             size="sm"
@@ -73,27 +73,6 @@ export default function SignInPage() {
                                   <>
                                     <Clerk.Icon />
                                     <>Google</>
-                                  </>
-                                )
-                              }
-                            </Clerk.Loading>
-                          </Button>
-                        </Clerk.Connection>
-                        <Clerk.Connection name="facebook" asChild>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            type="button"
-                            disabled={isGlobalLoading}
-                          >
-                            <Clerk.Loading scope="provider:facebook">
-                              {(isLoading) =>
-                                isLoading ? (
-                                  <LoaderCircleIcon className="size-4 animate-spin" />
-                                ) : (
-                                  <>
-                                    <Clerk.Icon />
-                                    Facebook
                                   </>
                                 )
                               }

--- a/app/auth/sign-up/[[...sign-up]]/page.tsx
+++ b/app/auth/sign-up/[[...sign-up]]/page.tsx
@@ -35,7 +35,7 @@ export default function SignUpPage() {
                       </CardDescription>
                     </CardHeader>
                     <CardContent className="grid gap-y-4">
-                      <div className="grid grid-cols-3 gap-x-4">
+                      <div className="grid grid-cols-2 gap-x-4">
                         <Clerk.Connection name="apple" asChild>
                           <Button
                             size="sm"
@@ -72,27 +72,6 @@ export default function SignUpPage() {
                                   <>
                                     <Clerk.Icon />
                                     Google
-                                  </>
-                                )
-                              }
-                            </Clerk.Loading>
-                          </Button>
-                        </Clerk.Connection>
-                        <Clerk.Connection name="facebook" asChild>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            type="button"
-                            disabled={isGlobalLoading}
-                          >
-                            <Clerk.Loading scope="provider:facebook">
-                              {(isLoading) =>
-                                isLoading ? (
-                                  <LoaderCircleIcon className="size-4 animate-spin" />
-                                ) : (
-                                  <>
-                                    <Clerk.Icon />
-                                    Facebook
                                   </>
                                 )
                               }

--- a/cliente/logo-theme.tsx
+++ b/cliente/logo-theme.tsx
@@ -17,7 +17,7 @@ export function LogoTheme({ mode }: { mode?: "light" | "dark" }) {
   return (
     <>
       {effectiveMode === "dark" && (
-        <div className="flex-col ">
+        <div className="flex-col">
           <div className="font-bold text-2xl tracking-wider text-center">
             VILEZA
           </div>

--- a/components/home/MosaicCategory.tsx
+++ b/components/home/MosaicCategory.tsx
@@ -16,42 +16,61 @@ const MosaicCategory = () => {
     }
   }, [categories.length, fetchCategories]);
 
-  if (isLoading || categories.length === 0) {
+  // Filtrar solo las categorías que tienen inHome === true
+  const homeCategories = categories.filter((category) => category.inHome === true);
+
+  if (isLoading || homeCategories.length === 0) {
     return null;
   }
 
+  // Imágenes de fallback
+  const fallbackImages = [
+    "/assets/mosaic/1.png",
+    "/assets/mosaic/2.png",
+    "/assets/mosaic/3.png",
+    "/assets/mosaic/4.png",
+  ];
+
   return (
     <div className="grid grid-cols-2 mt-3 sm:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 xl:pt-1 gap-4 h-[85vh]">
-      <div className="lg:row-span-2 h-full">
+      {homeCategories[0] && (
+        <div className="lg:row-span-2 h-full">
+          <CategoryCard
+            label={homeCategories[0].name || ""}
+            image={homeCategories[0].urlImage || fallbackImages[0]}
+            align="center"
+            fullHeight
+            link={homeCategories[0].id ? `/shop?categoryId=${homeCategories[0].id}` : "/shop"}
+          />
+        </div>
+      )}
+      {homeCategories[1] && (
+        <div className="lg:row-span-2 h-full">
+          <CategoryCard
+            label={homeCategories[1].name || ""}
+            image={homeCategories[1].urlImage || fallbackImages[1]}
+            align="center"
+            fullHeight
+            link={homeCategories[1].id ? `/shop?categoryId=${homeCategories[1].id}` : "/shop"}
+          />
+        </div>
+      )}
+      {homeCategories[2] && (
         <CategoryCard
-          label={categories[0]?.name || ""}
-          image="/assets/mosaic/1.png"
+          label={homeCategories[2].name || ""}
+          image={homeCategories[2].urlImage || fallbackImages[2]}
           align="center"
-          fullHeight
-          link={categories[0]?.id ? `/shop?categoryId=${categories[0].id}` : "/shop"}
+          link={homeCategories[2].id ? `/shop?categoryId=${homeCategories[2].id}` : "/shop"}
         />
-      </div>
-      <div className="lg:row-span-2 h-full">
+      )}
+      {homeCategories[3] && (
         <CategoryCard
-          label={categories[1]?.name || ""}
-          image="/assets/mosaic/2.png"
+          label={homeCategories[3].name || ""}
+          image={homeCategories[3].urlImage || fallbackImages[3]}
           align="center"
-          fullHeight
-          link={categories[1]?.id ? `/shop?categoryId=${categories[1].id}` : "/shop"}
+          link={homeCategories[3].id ? `/shop?categoryId=${homeCategories[3].id}` : "/shop"}
         />
-      </div>
-      <CategoryCard
-        label={categories[2]?.name || ""}
-        image="/assets/mosaic/3.png"
-        align="center"
-        link={categories[2]?.id ? `/shop?categoryId=${categories[2].id}` : "/shop"}
-      />
-      <CategoryCard
-        label={categories[3]?.name || ""}
-        image="/assets/mosaic/4.png"
-        align="center"
-        link={categories[3]?.id ? `/shop?categoryId=${categories[3].id}` : "/shop"}
-      />
+      )}
     </div>
   );
 };

--- a/components/interfaces/category.ts
+++ b/components/interfaces/category.ts
@@ -4,6 +4,8 @@ export interface Category {
     name: string;
     description: string;
     isActive: boolean;
+    urlImage?: string;
+    inHome?: boolean;
     createdAt: string;
     updatedAt: string;
   }

--- a/components/product/form-category.tsx
+++ b/components/product/form-category.tsx
@@ -14,9 +14,12 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
-import { EditIcon, PlusIcon } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { useState, useEffect } from "react";
+import { EditIcon, PlusIcon, Upload, X } from "lucide-react";
 import { Category } from "@/components/interfaces/category";
+import Image from "next/image";
+import { uploadFile } from "@/actions";
 
 type Props = {
   category?: Category;
@@ -30,10 +33,35 @@ export default function CategoryAlert({ category, onSave, onCancel }: Props) {
   const [formData, setFormData] = useState<Partial<Category>>({
     name: category?.name || "",
     description: category?.description || "",
+    urlImage: category?.urlImage || "",
+    inHome: category?.inHome || false,
     ...(category?.id && { id: category.id }),
   });
+
+  // Actualizar formData cuando cambia la categoría
+  useEffect(() => {
+    if (category) {
+      setFormData({
+        name: category.name || "",
+        description: category.description || "",
+        urlImage: category.urlImage || "",
+        inHome: category.inHome || false,
+        ...(category.id && { id: category.id }),
+      });
+    } else {
+      setFormData({
+        name: "",
+        description: "",
+        urlImage: "",
+        inHome: false,
+        id: undefined,
+      });
+    }
+  }, [category]);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [open, setOpen] = useState(false); // Controla apertura del modal
+  const [dragActive, setDragActive] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
 
   const handleInputChange = (
     field: keyof Category,
@@ -42,6 +70,65 @@ export default function CategoryAlert({ category, onSave, onCancel }: Props) {
     setFormData((prev) => ({ ...prev, [field]: value }));
     if (errors[field]) {
       setErrors((prev) => ({ ...prev, [field]: "" }));
+    }
+  };
+
+  const handleImageUpload = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+
+    const file = files[0];
+    if (!file.type.startsWith("image/")) {
+      setErrors((prev) => ({
+        ...prev,
+        urlImage: "Por favor selecciona un archivo de imagen",
+      }));
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      const result = await uploadFile(file);
+      if (result.statusCode === 201 && result.url) {
+        setFormData((prev) => ({ ...prev, urlImage: result.url }));
+        setErrors((prev) => ({ ...prev, urlImage: "" }));
+      } else {
+        setErrors((prev) => ({
+          ...prev,
+          urlImage: result.message || "Error al subir la imagen",
+        }));
+      }
+    } catch (err) {
+      console.error("Error al subir archivo:", err);
+      setErrors((prev) => ({
+        ...prev,
+        urlImage: "Error al subir la imagen",
+      }));
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const removeImage = () => {
+    setFormData((prev) => ({ ...prev, urlImage: "" }));
+  };
+
+  const handleDrag = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setDragActive(true);
+    } else if (e.type === "dragleave") {
+      setDragActive(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+      handleImageUpload(e.dataTransfer.files);
     }
   };
 
@@ -65,6 +152,8 @@ export default function CategoryAlert({ category, onSave, onCancel }: Props) {
       setFormData({
         name: "",
         description: "",
+        urlImage: "",
+        inHome: false,
         id: undefined,
       }); // Limpia el formulario
       setErrors({});
@@ -74,10 +163,12 @@ export default function CategoryAlert({ category, onSave, onCancel }: Props) {
   const handleCancel = () => {
     onCancel();
     setFormData({
-      name: "",
-      description: "",
-      id: undefined,
-    }); // Limpia
+      name: category?.name || "",
+      description: category?.description || "",
+      urlImage: category?.urlImage || "",
+      inHome: category?.inHome || false,
+      ...(category?.id && { id: category.id }),
+    }); // Restaura valores originales
     setErrors({});
     setOpen(false); // Cierra
   };
@@ -131,6 +222,92 @@ export default function CategoryAlert({ category, onSave, onCancel }: Props) {
             {errors.description && (
               <p className="text-sm text-red-500">{errors.description}</p>
             )}
+          </div>
+
+          {/* Upload Area */}
+          <div className="space-y-1">
+            <Label>Imagen de la categoría</Label>
+            <div
+              className={`border-2 border-dashed rounded-lg p-4 text-center transition-colors ${
+                dragActive
+                  ? "border-blue-500 bg-blue-50"
+                  : "border-gray-300 hover:border-gray-400"
+              }`}
+              onDragEnter={handleDrag}
+              onDragLeave={handleDrag}
+              onDragOver={handleDrag}
+              onDrop={handleDrop}
+            >
+              {formData.urlImage ? (
+                <div className="relative group">
+                  <Image
+                    src={formData.urlImage}
+                    alt="Imagen de categoría"
+                    width={200}
+                    height={200}
+                    className="w-full h-32 object-cover rounded-lg border mx-auto"
+                  />
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    className="absolute -top-2 -right-2 w-6 h-6 rounded-full p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                    onClick={removeImage}
+                  >
+                    <X className="w-3 h-3" />
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <Upload className="w-6 h-6 text-gray-400 mx-auto mb-2" />
+                  <p className="text-sm text-gray-600 mb-2">
+                    Arrastra una imagen aquí o haz clic para seleccionar
+                  </p>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => handleImageUpload(e.target.files)}
+                    className="hidden"
+                    id="category-image-upload"
+                    disabled={isUploading}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      document.getElementById("category-image-upload")?.click()
+                    }
+                    disabled={isUploading}
+                  >
+                    {isUploading ? "Subiendo..." : "Seleccionar Imagen"}
+                  </Button>
+                  <p className="text-xs text-gray-500 mt-2">
+                    PNG, JPG hasta 10MB
+                  </p>
+                </>
+              )}
+            </div>
+            {errors.urlImage && (
+              <p className="text-sm text-red-500">{errors.urlImage}</p>
+            )}
+          </div>
+
+          {/* InHome Switch */}
+          <div className="space-y-1">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="inHome">Mostrar en inicio</Label>
+              <Switch
+                id="inHome"
+                checked={formData.inHome ? true : false}
+                onCheckedChange={(checked) =>
+                  handleInputChange("inHome", checked)
+                }
+              />
+            </div>
+            <p className="text-xs text-gray-500">
+              Activa esta opción para mostrar la categoría en la página de inicio
+            </p>
           </div>
 
           <AlertDialogFooter className="pt-4">

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Categories now support an image and a flag to display on the home page. Admin UI updated to show category images and 'En Inicio' status, and the category form allows image upload and toggling home display. Home mosaic now only shows categories marked for home display, using their images if available. Removed Facebook auth provider from sign-in and sign-up pages.